### PR TITLE
fix: Python 3.9 compat and shell script unbound variable bug

### DIFF
--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional, Union
 
 SCRIPT_DIR = Path(__file__).parent
 API_SCRIPT = SCRIPT_DIR / "apple_music_api.sh"
@@ -25,7 +26,7 @@ DEFAULT_CONFIG = {
 }
 
 
-def load_config(path: str | None = None) -> dict:
+def load_config(path: Optional[str] = None) -> dict:
     """Load user configuration from JSON, falling back to defaults.
 
     If no path is given, looks at ~/.apple-music-dj/config.json.
@@ -51,7 +52,7 @@ def load_config(path: str | None = None) -> dict:
         return config
 
 
-def save_config(config: dict, path: str | None = None):
+def save_config(config: dict, path: Optional[str] = None):
     """Write config to JSON with restrictive permissions."""
     config_path = Path(path) if path else DEFAULT_CONFIG_PATH
     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -75,7 +76,7 @@ def require_env_tokens():
         sys.exit(1)
 
 
-def call_api(command: str, *args, raw: bool = False) -> dict | list | str | None:
+def call_api(command: str, *args, raw: bool = False) -> Union[dict, list, str, None]:
     """Call apple_music_api.sh and parse JSON output.
 
     If raw=True, return stdout as a stripped string instead of parsing JSON.
@@ -119,7 +120,7 @@ def load_profile(path: str) -> dict:
         sys.exit(1)
 
 
-def search_artist(sf: str, name: str) -> dict | None:
+def search_artist(sf: str, name: str) -> Optional[dict]:
     """Search for an artist by name and return the top match."""
     result = call_api("search", sf, name, "artists")
     if not result:
@@ -128,7 +129,7 @@ def search_artist(sf: str, name: str) -> dict | None:
     return artists[0] if artists else None
 
 
-def search_album(sf: str, query: str) -> dict | None:
+def search_album(sf: str, query: str) -> Optional[dict]:
     """Search for an album by name and return the top match."""
     result = call_api("search", sf, query, "albums")
     if not result:

--- a/scripts/apple_music_api.sh
+++ b/scripts/apple_music_api.sh
@@ -25,9 +25,10 @@ _retry() {
   local max_retries=3
   local delay=1
   local attempt=0
-  local tmpfile
+  local tmpfile=""
   tmpfile=$(mktemp "${TMPDIR:-/tmp}/am_api_XXXXXX")
-  trap 'rm -f "$tmpfile"' RETURN INT TERM EXIT
+  # Only use RETURN trap — EXIT persists globally and outlives the local var
+  trap 'rm -f "$tmpfile"' RETURN
 
   while (( attempt <= max_retries )); do
     local http_code

--- a/scripts/catalog_explorer.py
+++ b/scripts/catalog_explorer.py
@@ -21,6 +21,7 @@ import sys
 from pathlib import Path
 
 from _common import call_api, load_profile, search_artist, search_album, get_album_tracks
+from typing import Optional, Union
 
 SCRIPT_DIR = Path(__file__).parent
 
@@ -115,7 +116,7 @@ def cmd_gap_analysis(profile: dict, sf: str) -> dict:
 
 # ── Album Deep Dive ──────────────────────────────────────────────
 
-def cmd_album_dive(sf: str, album_query: str, artist_hint: str | None = None) -> dict:
+def cmd_album_dive(sf: str, album_query: str, artist_hint: Optional[str] = None) -> dict:
     """Deep dive into a specific album."""
     query = f"{album_query} {artist_hint}" if artist_hint else album_query
     album = search_album(sf, query)

--- a/scripts/compatibility.py
+++ b/scripts/compatibility.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 
 from _common import call_api, load_profile
+from typing import Optional, Union
 
 SCRIPT_DIR = Path(__file__).parent
 
@@ -66,7 +67,7 @@ def genre_overlap_score(genres_a: list[dict], genres_b: list[dict]) -> float:
 
 # ── Artist Compatibility ─────────────────────────────────────────
 
-def resolve_artist(sf: str, query: str) -> dict | None:
+def resolve_artist(sf: str, query: str) -> Optional[dict]:
     """Search for an artist by name and return their catalog data."""
     from _common import search_artist
     found = search_artist(sf, query)

--- a/scripts/daily_pick.py
+++ b/scripts/daily_pick.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from _common import call_api, load_profile
+from typing import Optional, Union
 
 SCRIPT_DIR = Path(__file__).parent
 
@@ -65,7 +66,7 @@ def get_time_context() -> dict:
 
 # ── Candidate Sourcing ───────────────────────────────────────────
 
-def get_candidates(profile: dict, sf: str, context: dict | None = None) -> list[dict]:
+def get_candidates(profile: dict, sf: str, context: Optional[dict] = None) -> list[dict]:
     """Gather candidate tracks from multiple sources."""
     candidates = []
     top_artists = profile.get("top_artists", [])[:15]
@@ -126,7 +127,7 @@ def get_candidates(profile: dict, sf: str, context: dict | None = None) -> list[
     return candidates
 
 
-def score_candidate(candidate: dict, profile: dict, context: dict | None = None, rng: random.Random | None = None) -> float:
+def score_candidate(candidate: dict, profile: dict, context: Optional[dict] = None, rng: Optional[random.Random] = None) -> float:
     """Score a candidate track. Higher = better pick."""
     _rng = rng or random.Random()
     score = 0.5  # base score

--- a/scripts/playlist_health.py
+++ b/scripts/playlist_health.py
@@ -20,6 +20,7 @@ from collections import Counter
 from pathlib import Path
 
 from _common import call_api, load_config, load_profile, require_env_tokens
+from typing import Optional, Union
 
 SCRIPT_DIR = Path(__file__).parent
 
@@ -101,7 +102,7 @@ def check_playlist(playlist_id: str, sf: str) -> dict:
     }
 
 
-def find_replacement(sf: str, name: str, artist: str) -> dict | None:
+def find_replacement(sf: str, name: str, artist: str) -> Optional[dict]:
     """Search catalog for a replacement track (same song, different catalog ID)."""
     query = f"{name} {artist}"
     result = call_api("search", sf, query, "songs")

--- a/scripts/strategy_engine.py
+++ b/scripts/strategy_engine.py
@@ -39,6 +39,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from _common import (
+from typing import Optional, Union
     call_api,
     get_album_tracks,
     load_config,
@@ -637,8 +638,8 @@ def strategy_refresh(profile: dict, sf: str, playlist_id: str, target_add: int =
 
 # ── Playlist Creation ────────────────────────────────────────────
 
-def generate_name(strategy: str, mood: str | None = None,
-                  profile: dict | None = None) -> str:
+def generate_name(strategy: str, mood: Optional[str] = None,
+                  profile: Optional[dict] = None) -> str:
     """Auto-generate a playlist name."""
     date_str = datetime.now(timezone.utc).strftime("%b %Y")
     if strategy == "deep-cuts":
@@ -659,7 +660,7 @@ def generate_name(strategy: str, mood: str | None = None,
     return f"Apple Music DJ · {date_str}"
 
 
-def generate_description(strategy: str, mood: str | None = None,
+def generate_description(strategy: str, mood: Optional[str] = None,
                          track_count: int = 0) -> str:
     """Auto-generate a playlist description."""
     descriptions = {

--- a/scripts/taste_profiler.py
+++ b/scripts/taste_profiler.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from _common import call_api, require_env_tokens
+from typing import Optional, Union
 
 SCRIPT_DIR = Path(__file__).parent
 
@@ -37,7 +38,7 @@ def log(msg: str, verbose: bool = True):
         print(f"  → {msg}", file=sys.stderr)
 
 
-def load_cache(path: str, max_age_hours: int) -> dict | None:
+def load_cache(path: str, max_age_hours: int) -> Optional[dict]:
     """Load cached profile if it exists and is fresh enough."""
     try:
         p = Path(path)
@@ -163,7 +164,7 @@ def compute_variety_score(artists: list[dict], tracks: list[dict]) -> float:
     return round(min(ratio * 1.5, 1.0), 2)  # scale up slightly, cap at 1
 
 
-def compute_mainstream_score(top_artists: list[dict], chart_data: dict | None) -> float:
+def compute_mainstream_score(top_artists: list[dict], chart_data: Optional[dict]) -> float:
     """How mainstream is the taste? Compare artists against charts."""
     if not chart_data or not top_artists:
         return 0.5  # unknown
@@ -182,7 +183,7 @@ def compute_mainstream_score(top_artists: list[dict], chart_data: dict | None) -
     return round(overlap / len(user_names), 2) if user_names else 0.5
 
 
-def extract_ratings(ratings_data: dict | None) -> tuple[list[str], list[str]]:
+def extract_ratings(ratings_data: Optional[dict]) -> tuple[list[str], list[str]]:
     """Extract loved and disliked song IDs from ratings."""
     loved_ids = []
     disliked_song_ids = []
@@ -199,7 +200,7 @@ def extract_ratings(ratings_data: dict | None) -> tuple[list[str], list[str]]:
     return loved_ids, disliked_song_ids
 
 
-def extract_replay_highlights(summary_data: dict | None, milestones_data: dict | None) -> dict:
+def extract_replay_highlights(summary_data: Optional[dict], milestones_data: Optional[dict]) -> dict:
     """Extract Replay / Music Summaries highlights."""
     highlights = {
         "available": False,


### PR DESCRIPTION
## What

Two bugs that affect the taste profiler's ability to gather complete data.

### 1. Python 3.9 compatibility
Scripts used PEP 604 union type hints (`str | None`) which require Python 3.10+. macOS ships with Python 3.9 by default, causing an immediate `TypeError` on import.

**Fix:** Replace with `typing.Optional` / `typing.Union` across all affected scripts.

### 2. Shell script unbound variable (`apple_music_api.sh`)
The `_retry()` function set a `trap ... EXIT` referencing a local `$tmpfile` variable. The EXIT trap persists globally after the function returns, so when the calling command exits, bash tries to evaluate `$tmpfile` which no longer exists under `set -u` (nounset).

This caused `ratings`, `replay-summary`, and `replay-milestones` API calls to silently fail — meaning taste profiles were missing loved/disliked tracks and all Replay data.

**Fix:** Use `trap ... RETURN` only (function-scoped), don't set EXIT trap from within functions.

## Files changed
- `scripts/_common.py` — typing imports + Optional/Union
- `scripts/apple_music_api.sh` — trap fix in `_retry()`
- `scripts/taste_profiler.py`, `strategy_engine.py`, `daily_pick.py`, `catalog_explorer.py`, `compatibility.py`, `playlist_health.py` — type hint compat

## Testing
- Verified taste profiler runs clean on Python 3.9 and 3.13
- Ratings/replay API calls no longer produce warnings
- All 8 files, 27 insertions, 19 deletions